### PR TITLE
Fix: Avoid warning by accessing page.node.site instead of page.site.

### DIFF
--- a/djangocms_moderation/emails.py
+++ b/djangocms_moderation/emails.py
@@ -31,7 +31,7 @@ def _send_email(request, action, recipients, subject, template):
 
     context = {
         'page': page,
-        'page_url': get_absolute_url(page_url, site=page.site),
+        'page_url': get_absolute_url(page_url, site=page.node.site),
         'author_name': author_name,
         'by_user_name': action.get_by_user_name(),
         'moderator_name': moderator_name,


### PR DESCRIPTION
Simple fix to get a clean test output.