### PR TITLE
Returns a shorter UUID hexadecimal instead of a UUID instance

### DIFF
--- a/djangocms_moderation/backends.py
+++ b/djangocms_moderation/backends.py
@@ -2,4 +2,4 @@ import uuid
 
 
 def uuid4_backend(**kwargs):
-    return uuid.uuid4()
+    return uuid.uuid4().hex


### PR DESCRIPTION
This pull request contains a small fix for a major issue. The default reference number back-end uses ```uuid.uuid4()``` in returning a 35 char string from a UUID Instance on a ```models.CharField``` field with a max_length of 32, thereby causing a DataError exception when creating a new moderation request.

This fails on a Postgres database backend, so we have returned an hexadecimal value instead.