### PR TITLE
remove publish button

### DIFF
--- a/djangocms_moderation/cms_toolbars.py
+++ b/djangocms_moderation/cms_toolbars.py
@@ -4,8 +4,8 @@ from django.utils.translation import ugettext_lazy as _
 from cms.toolbar_pool import toolbar_pool
 from cms.utils.urlutils import add_url_parameters
 
-from djangocms_versioning.models import Version
 from djangocms_versioning.cms_toolbars import VersioningToolbar
+from djangocms_versioning.models import Version
 
 from .models import ModerationRequest
 from .utils import get_admin_url
@@ -19,6 +19,9 @@ class ModerationToolbar(VersioningToolbar):
         }
 
     def _add_publish_button(self):
+        """
+        Override djangocms_versioning publish button
+        """
         pass
 
     def post_template_populate(self):
@@ -57,6 +60,7 @@ class ModerationToolbar(VersioningToolbar):
                 url=url,
                 side=self.toolbar.RIGHT,
             )
+
 
 toolbar_pool.unregister(VersioningToolbar)
 toolbar_pool.register(ModerationToolbar)

--- a/djangocms_moderation/forms.py
+++ b/djangocms_moderation/forms.py
@@ -8,6 +8,7 @@ from django.forms.forms import NON_FIELD_ERRORS
 from django.utils.translation import ugettext, ugettext_lazy as _
 
 from adminsortable2.admin import CustomInlineFormSet
+
 from djangocms_versioning.models import Version
 
 from .constants import (

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,8 +1,6 @@
 from django.contrib import admin
 from django.urls import reverse
 
-from djangocms_versioning.test_utils.factories import PageVersionFactory
-
 from djangocms_moderation import conf, constants
 from djangocms_moderation.admin import (
     ModerationCollectionAdmin,
@@ -14,6 +12,7 @@ from djangocms_moderation.models import (
     ModerationRequest,
     Workflow,
 )
+from djangocms_versioning.test_utils.factories import PageVersionFactory
 
 from .utils.base import BaseTestCase
 

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -3,8 +3,6 @@ import mock
 from django.contrib.admin import ACTION_CHECKBOX_NAME
 from django.urls import reverse
 
-from djangocms_versioning.test_utils.factories import PageVersionFactory
-
 from djangocms_moderation import constants
 from djangocms_moderation.admin import ModerationRequestAdmin
 from djangocms_moderation.constants import ACTION_REJECTED
@@ -14,6 +12,7 @@ from djangocms_moderation.models import (
     Role,
     Workflow,
 )
+from djangocms_versioning.test_utils.factories import PageVersionFactory
 
 from .utils.base import BaseTestCase
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,12 +7,11 @@ from django.utils.translation import ugettext_lazy as _
 
 from cms.utils.urlutils import add_url_parameters
 
-from djangocms_versioning.test_utils.factories import PageVersionFactory
-
 from djangocms_moderation import constants
 from djangocms_moderation.forms import CollectionItemForm
 from djangocms_moderation.models import ModerationCollection, ModerationRequest
 from djangocms_moderation.utils import get_admin_url
+from djangocms_versioning.test_utils.factories import PageVersionFactory
 
 from .utils.base import BaseViewTestCase
 

--- a/tests/utils/base.py
+++ b/tests/utils/base.py
@@ -1,8 +1,6 @@
 from django.contrib.auth.models import Group, User
 from django.test import TestCase
 
-from djangocms_versioning.test_utils.factories import PageVersionFactory
-
 from djangocms_moderation import constants
 from djangocms_moderation.models import (
     ModerationCollection,
@@ -10,6 +8,7 @@ from djangocms_moderation.models import (
     Role,
     Workflow,
 )
+from djangocms_versioning.test_utils.factories import PageVersionFactory
 
 
 class BaseTestCase(TestCase):


### PR DESCRIPTION
Another alternative would be to extend VersioningToolbar and override its methods. Which do you prefer?

```python
VersioningToolbar = toolbar_pool.toolbars['djangocms_versioning.cms_toolbars.VersioningToolbar']
class ModerationToolbar(VersioningToolbar):
...
toolbar_pool.unregister(VersioningToolbar)
toolbar_pool.register(ModerationToolbar)
```