### PR TITLE
fix: Refactor flawed add to collection XSS redirect sanitisation added in 1.0.26

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Refactor flawed add to collection XSS redirect sanitisation added in 1.0.26
 * Python 3.8, 3.9 support added
 * Django 3.0, 3.1 and 3.2 support added
 * Python 3.5 and 3.6 support removed

--- a/djangocms_moderation/views.py
+++ b/djangocms_moderation/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from django.contrib import admin, messages
 from django.db import transaction
 from django.http import Http404, HttpResponseRedirect
@@ -86,7 +88,9 @@ class CollectionItemsView(FormView):
                 allowed_hosts=self.request.get_host(),
                 require_https=self.request.is_secure(),
             )
-            return_to_url = urlquote(return_to_url)
+            # Protect against refracted XSS attacks
+            # Allow : in http://, ?=& for GET parameters
+            return_to_url = quote(return_to_url, safe='/:?=&')
             if not url_is_safe:
                 return_to_url = self.request.path
             return HttpResponseRedirect(return_to_url)

--- a/djangocms_moderation/views.py
+++ b/djangocms_moderation/views.py
@@ -6,7 +6,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.http import is_safe_url, urlquote
+from django.utils.http import is_safe_url
 from django.utils.translation import gettext_lazy as _, ngettext
 from django.views.generic import FormView
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -597,6 +597,7 @@ class CollectionItemsViewAddingRequestsTestCase(CMSTestCase):
             messages,
         )
 
+
 class CollectionItemsViewTest(CMSTestCase):
     def setUp(self):
         self.client.force_login(self.get_superuser())


### PR DESCRIPTION
An issue has been recorded where the added to collection redirect view incorrectly redirects from djangocms-moderation version 1.0.26+

The redirect is broken in 1.0.26 because a security fix was implemented to prevent reflected XSS attacks hence the need for sanitisation. 