### PR TITLE
fix: Broken test suite dependancies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Unreleased
 ==========
-
+* Pin versioning to a python 3.6 compatible version matching this release stream
 
 1.0.28 (2021-10-18)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Unreleased
 ==========
-* Pin versioning to a python 3.6 compatible version matching this release stream
+* Pin the following packages to a python 3.6 compatible version matching this release stream: django-admin-sortable2, djangocms-text-ckeditor, djangocms-version-locking and djangocms-versioning.  
 
 1.0.28 (2021-10-18)
 ===================

--- a/tests/requirements/dj11_cms40.txt
+++ b/tests/requirements/dj11_cms40.txt
@@ -1,7 +1,6 @@
 -r requirements_base.txt
 
 Django>=1.11,<2.0
-django-admin-sortable2<1.0.0
 django-filer<2.0.0
 django-classy-tags<2.0.0
 django-sekizai<2.0.0

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -14,4 +14,4 @@ python-dateutil>=2.4
 https://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
 https://github.com/django-cms/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
 https://github.com/django-cms/djangocms-versioning/tarball/release/0.0.x#egg=djangocms-versioning
-https://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking
+https://github.com/FidelityInternational/djangocms-version-locking/tarball/release/0.0.x#egg=djangocms-version-locking

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -1,5 +1,6 @@
 cachetools
 coverage
+django-admin-sortable2<1.0
 django_polymorphic==2.0.3
 django-simple-captcha
 djangocms_helper

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -13,5 +13,5 @@ python-dateutil>=2.4
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
 https://github.com/django-cms/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
-https://github.com/django-cms/djangocms-versioning/tarball/master#egg=djangocms-versioning
+https://github.com/django-cms/djangocms-versioning/tarball/release/0.0.x#egg=djangocms-versioning
 https://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -13,6 +13,6 @@ python-dateutil>=2.4
 
 # Unreleased django-cms 4.0 compatible packages
 https://github.com/django-cms/django-cms/tarball/release/4.0.x#egg=django-cms
-https://github.com/django-cms/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
+https://github.com/django-cms/djangocms-text-ckeditor/tarball/support/4.0.0#egg=djangocms-text-ckeditor
 https://github.com/django-cms/djangocms-versioning/tarball/release/0.0.x#egg=djangocms-versioning
 https://github.com/FidelityInternational/djangocms-version-locking/tarball/release/0.0.x#egg=djangocms-version-locking


### PR DESCRIPTION
Pin the following packages to a version that the moderation release/1.0.x workstream follows:
- django-admin-sortable2
- djangocms-text-ckeditor
- djangocms-version-locking
- djangocms-versioning
