### PR TITLE
fix: Add to collection should automatically add deeply nested versionable objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Add to collection should automatically add deeply nested draft versioned objects #205
 * fix: Refactor flawed add to collection XSS redirect sanitisation added in 1.0.26
 
 2.0.0 (2022-01-18)

--- a/djangocms_moderation/helpers.py
+++ b/djangocms_moderation/helpers.py
@@ -168,7 +168,7 @@ def _get_nested_moderated_children_from_placeholder(instance, placeholder, paren
 
         candidate = getattr(instance, field.name)
 
-        # Break early if the field is the placeholder
+        # Break early if the field is a placeholder or None
         if candidate == placeholder or not candidate:
             continue
 

--- a/djangocms_moderation/helpers.py
+++ b/djangocms_moderation/helpers.py
@@ -6,8 +6,8 @@ from django.template.defaultfilters import truncatechars
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from cms.utils.plugins import downcast_plugins
 from cms.models import CMSPlugin
+from cms.utils.plugins import downcast_plugins
 
 from djangocms_versioning import versionables
 from djangocms_versioning.constants import DRAFT

--- a/djangocms_moderation/helpers.py
+++ b/djangocms_moderation/helpers.py
@@ -165,6 +165,10 @@ def get_moderated_children_from_placeholder(placeholder, parent_version_filters)
         for field in plugin._meta.get_fields():
             if not field.is_relation or field.auto_created:
                 continue
+            """
+            Plugin: Some plugin
+            field.name: link
+            """
             candidate = getattr(plugin, field.name)
             try:
                 versionable = versionables.for_grouper(candidate)

--- a/djangocms_moderation/helpers.py
+++ b/djangocms_moderation/helpers.py
@@ -177,7 +177,9 @@ def _get_nested_moderated_children_from_placeholder_plugin(instance, placeholder
         try:
             versionable = versionables.for_grouper(candidate)
         except KeyError:
-            yield from _get_nested_moderated_children_from_placeholder_plugin(candidate, placeholder, parent_version_filters)
+            yield from _get_nested_moderated_children_from_placeholder_plugin(
+                candidate, placeholder, parent_version_filters
+            )
             continue
 
         version = _get_moderatable_version(

--- a/djangocms_moderation/helpers.py
+++ b/djangocms_moderation/helpers.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from cms.utils.plugins import downcast_plugins
+from cms.models import CMSPlugin
 
 from djangocms_versioning import versionables
 from djangocms_versioning.constants import DRAFT
@@ -168,15 +169,15 @@ def _get_nested_moderated_children_from_placeholder(instance, placeholder, paren
 
         candidate = getattr(instance, field.name)
 
-        # Break early if the field is a placeholder or None
-        if candidate == placeholder or not candidate:
+        # Break early if the field is None, a placeholder, or is a CMSPlugin instance
+        # We do this to save unnecessary processing
+        if not candidate or candidate == placeholder or isinstance(candidate, CMSPlugin):
             continue
 
         try:
             versionable = versionables.for_grouper(candidate)
         except KeyError:
             yield from _get_nested_moderated_children_from_placeholder(candidate, placeholder, parent_version_filters)
-
             continue
 
         version = _get_moderatable_version(

--- a/djangocms_moderation/helpers.py
+++ b/djangocms_moderation/helpers.py
@@ -158,7 +158,7 @@ def _get_moderatable_version(versionable, grouper, parent_version_filters):
         return
 
 
-def _get_nested_moderated_children_from_placeholder(instance, placeholder, parent_version_filters):
+def _get_nested_moderated_children_from_placeholder_plugin(instance, placeholder, parent_version_filters):
     """
     Find all nested versionable objects, traverses through all attached models until it finds
     any models that are versioned.
@@ -177,7 +177,7 @@ def _get_nested_moderated_children_from_placeholder(instance, placeholder, paren
         try:
             versionable = versionables.for_grouper(candidate)
         except KeyError:
-            yield from _get_nested_moderated_children_from_placeholder(candidate, placeholder, parent_version_filters)
+            yield from _get_nested_moderated_children_from_placeholder_plugin(candidate, placeholder, parent_version_filters)
             continue
 
         version = _get_moderatable_version(
@@ -192,4 +192,4 @@ def get_moderated_children_from_placeholder(placeholder, parent_version_filters)
     Get all moderated children version objects from a placeholder
     """
     for plugin in downcast_plugins(placeholder.get_plugins()):
-        yield from _get_nested_moderated_children_from_placeholder(plugin, placeholder, parent_version_filters)
+        yield from _get_nested_moderated_children_from_placeholder_plugin(plugin, placeholder, parent_version_filters)

--- a/djangocms_moderation/helpers.py
+++ b/djangocms_moderation/helpers.py
@@ -158,7 +158,10 @@ def _get_moderatable_version(versionable, grouper, parent_version_filters):
 
 
 def _get_nested_moderated_children_from_placeholder(instance, placeholder, parent_version_filters):
-
+    """
+    Find all nested versionable objects, traverses through all attached models until it finds
+    any models that are versioned.
+    """
     for field in instance._meta.get_fields():
         if not field.is_relation or field.auto_created:
             continue
@@ -184,6 +187,8 @@ def _get_nested_moderated_children_from_placeholder(instance, placeholder, paren
 
 
 def get_moderated_children_from_placeholder(placeholder, parent_version_filters):
+    """
+    Get all moderated children version objects from a placeholder
+    """
     for plugin in downcast_plugins(placeholder.get_plugins()):
         yield from _get_nested_moderated_children_from_placeholder(plugin, placeholder, parent_version_filters)
-

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -249,7 +249,7 @@ class ModeratedChildrenTestCase(CMSTestCase):
         poll_version = PollVersionFactory(
             created_by=self.user, content__language=language
         )
-        nested_plugin = NestedPollPluginFactory(placeholder=placeholder, nested_poll__poll=poll_version.content.poll)
+        NestedPollPluginFactory(placeholder=placeholder, nested_poll__poll=poll_version.content.poll)
 
         moderated_children = list(
             get_moderated_children_from_placeholder(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -33,7 +33,7 @@ from .utils.factories import (
     PollPluginFactory,
     PollVersionFactory,
 )
-from .utils.moderated_polls.factories import NestedPollPluginFactory
+from .utils.moderated_polls.factories import DeeplyNestedPollPluginFactory, NestedPollPluginFactory
 
 
 @skip("Confirmation page feature doesn't support 1.0.x yet")
@@ -236,9 +236,10 @@ class ModeratedChildrenTestCase(CMSTestCase):
         self.assertEqual(page_1_moderated_children, [pg_1_poll_version])
         self.assertEqual(page_2_moderated_children, [pg_2_poll_version])
 
-    def test_get_moderated_children_from_placeholder_has_only_registered_model(self):
+    def test_get_moderated_children_from_placeholder_gets_nested_models(self):
         """
-        The moderated model is the only model registered with moderation
+        Versionable models that are nested inside a custom plugin model
+        can be found when adding to a collection.
         """
         pg_version = PageVersionFactory(created_by=self.user)
         language = pg_version.content.language
@@ -249,7 +250,36 @@ class ModeratedChildrenTestCase(CMSTestCase):
         poll_version = PollVersionFactory(
             created_by=self.user, content__language=language
         )
+        # Nested versioned poll
         NestedPollPluginFactory(placeholder=placeholder, nested_poll__poll=poll_version.content.poll)
+
+        moderated_children = list(
+            get_moderated_children_from_placeholder(
+                placeholder, {"language": pg_version.content.language}
+            )
+        )
+
+        self.assertEqual(moderated_children, [poll_version])
+
+    def test_get_moderated_children_from_placeholder_gets_deeply_nested_models(self):
+        """
+        Versionable models that are deeply nested inside a custom plugin model
+        can be found when adding to a collection.
+        """
+        pg_version = PageVersionFactory(created_by=self.user)
+        language = pg_version.content.language
+
+        # Populate page
+        placeholder = PlaceholderFactory(source=pg_version.content)
+        # Moderated plugin
+        poll_version = PollVersionFactory(
+            created_by=self.user, content__language=language
+        )
+        # Deeply nested versioned poll
+        DeeplyNestedPollPluginFactory(
+            placeholder=placeholder,
+            deeply_nested_poll__nested_poll__poll=poll_version.content.poll
+        )
 
         moderated_children = list(
             get_moderated_children_from_placeholder(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -33,7 +33,10 @@ from .utils.factories import (
     PollPluginFactory,
     PollVersionFactory,
 )
-from .utils.moderated_polls.factories import DeeplyNestedPollPluginFactory, NestedPollPluginFactory
+from .utils.moderated_polls.factories import (
+    DeeplyNestedPollPluginFactory,
+    NestedPollPluginFactory,
+)
 
 
 @skip("Confirmation page feature doesn't support 1.0.x yet")

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -10,6 +10,7 @@ from djangocms_versioning.test_utils.factories import (
     AbstractVersionFactory,
     PageVersionFactory,
 )
+from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from djangocms_moderation.models import (
@@ -45,7 +46,7 @@ def get_plugin_language(plugin):
     # also be None unless set manually
 
 
-class PlaceholderFactory(factory.django.DjangoModelFactory):
+class PlaceholderFactory(DjangoModelFactory):
     default_width = FuzzyInteger(0, 25)
     slot = FuzzyText(length=2, chars=string.digits)
     # NOTE: When using this factory you will probably want to set
@@ -55,14 +56,14 @@ class PlaceholderFactory(factory.django.DjangoModelFactory):
         model = Placeholder
 
 
-class PollFactory(factory.django.DjangoModelFactory):
+class PollFactory(DjangoModelFactory):
     name = FuzzyText(length=6)
 
     class Meta:
         model = Poll
 
 
-class PollContentFactory(factory.django.DjangoModelFactory):
+class PollContentFactory(DjangoModelFactory):
     poll = factory.SubFactory(PollFactory)
     language = FuzzyChoice(["en", "fr", "it"])
     text = FuzzyText(length=24)
@@ -71,7 +72,7 @@ class PollContentFactory(factory.django.DjangoModelFactory):
         model = PollContent
 
 
-class PollPluginFactory(factory.django.DjangoModelFactory):
+class PollPluginFactory(DjangoModelFactory):
     language = factory.LazyAttribute(get_plugin_language)
     placeholder = factory.SubFactory(PlaceholderFactory)
     parent = None
@@ -93,14 +94,14 @@ class PollVersionFactory(AbstractVersionFactory):
 # None Moderated Poll App factories
 
 
-class NoneModeratedPollFactory(factory.django.DjangoModelFactory):
+class NoneModeratedPollFactory(DjangoModelFactory):
     name = FuzzyText(length=6)
 
     class Meta:
         model = NoneModeratedPoll
 
 
-class NoneModeratedPollContentFactory(factory.django.DjangoModelFactory):
+class NoneModeratedPollContentFactory(DjangoModelFactory):
     poll = factory.SubFactory(NoneModeratedPollFactory)
     language = FuzzyChoice(["en", "fr", "it"])
     text = FuzzyText(length=24)
@@ -116,7 +117,7 @@ class NoneModeratedPollVersionFactory(AbstractVersionFactory):
         model = Version
 
 
-class NoneModeratedPollPluginFactory(factory.django.DjangoModelFactory):
+class NoneModeratedPollPluginFactory(DjangoModelFactory):
     language = factory.LazyAttribute(get_plugin_language)
     placeholder = factory.SubFactory(PlaceholderFactory)
     parent = None
@@ -128,7 +129,7 @@ class NoneModeratedPollPluginFactory(factory.django.DjangoModelFactory):
         model = NoneModeratedPollPlugin
 
 
-class UserFactory(factory.django.DjangoModelFactory):
+class UserFactory(DjangoModelFactory):
     username = FuzzyText(length=12)
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
@@ -145,14 +146,14 @@ class UserFactory(factory.django.DjangoModelFactory):
         return manager.create_user(*args, **kwargs)
 
 
-class WorkflowFactory(factory.django.DjangoModelFactory):
+class WorkflowFactory(DjangoModelFactory):
     name = FuzzyText(length=12)
 
     class Meta:
         model = Workflow
 
 
-class ModerationCollectionFactory(factory.django.DjangoModelFactory):
+class ModerationCollectionFactory(DjangoModelFactory):
     name = FuzzyText(length=12)
     author = factory.SubFactory(UserFactory)
     workflow = factory.SubFactory(WorkflowFactory)
@@ -161,7 +162,7 @@ class ModerationCollectionFactory(factory.django.DjangoModelFactory):
         model = ModerationCollection
 
 
-class ModerationRequestFactory(factory.django.DjangoModelFactory):
+class ModerationRequestFactory(DjangoModelFactory):
     collection = factory.SubFactory(ModerationCollectionFactory)
     version = factory.SubFactory(PageVersionFactory)
     language = 'en'
@@ -171,7 +172,7 @@ class ModerationRequestFactory(factory.django.DjangoModelFactory):
         model = ModerationRequest
 
 
-class RootModerationRequestTreeNodeFactory(factory.django.DjangoModelFactory):
+class RootModerationRequestTreeNodeFactory(DjangoModelFactory):
     moderation_request = factory.SubFactory(ModerationRequestFactory)
 
     class Meta:
@@ -183,7 +184,7 @@ class RootModerationRequestTreeNodeFactory(factory.django.DjangoModelFactory):
         return model_class.add_root(*args, **kwargs)
 
 
-class ChildModerationRequestTreeNodeFactory(factory.django.DjangoModelFactory):
+class ChildModerationRequestTreeNodeFactory(DjangoModelFactory):
     moderation_request = factory.SubFactory(ModerationRequestFactory)
     parent = factory.SubFactory(RootModerationRequestTreeNodeFactory)
 

--- a/tests/utils/moderated_polls/cms_plugins.py
+++ b/tests/utils/moderated_polls/cms_plugins.py
@@ -1,12 +1,20 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
-from .models import PollPlugin as Poll
+from .models import PollPlugin as Poll, NestedPollPlugin as NestedPoll
 
 
 @plugin_pool.register_plugin
 class PollPlugin(CMSPluginBase):
     model = Poll
     name = "Poll"
+    allow_children = True
+    render_template = "polls/poll.html"
+
+
+@plugin_pool.register_plugin
+class NestedPollPlugin(CMSPluginBase):
+    model = NestedPoll
+    name = "NestedPoll"
     allow_children = True
     render_template = "polls/poll.html"

--- a/tests/utils/moderated_polls/cms_plugins.py
+++ b/tests/utils/moderated_polls/cms_plugins.py
@@ -1,7 +1,11 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
-from .models import PollPlugin as Poll, NestedPollPlugin as NestedPoll
+from .models import (
+    DeeplyNestedPollPlugin as DeeplyNestedPoll,
+    NestedPollPlugin as NestedPoll,
+    PollPlugin as Poll,
+)
 
 
 @plugin_pool.register_plugin
@@ -17,4 +21,12 @@ class NestedPollPlugin(CMSPluginBase):
     model = NestedPoll
     name = "NestedPoll"
     allow_children = True
-    render_template = "polls/poll.html"
+    render_template = "polls/nested_poll.html"
+
+
+@plugin_pool.register_plugin
+class DeeplyNestedPollPlugin(CMSPluginBase):
+    model = DeeplyNestedPoll
+    name = "DeeplyNestedPoll"
+    allow_children = True
+    render_template = "polls/deeply_nested_poll.html"

--- a/tests/utils/moderated_polls/factories.py
+++ b/tests/utils/moderated_polls/factories.py
@@ -2,12 +2,18 @@ import factory
 
 from factory.django import DjangoModelFactory
 
-from .models import NestedPoll, NestedPollPlugin
+from .models import (
+    DeeplyNestedPoll,
+    DeeplyNestedPollPlugin,
+    NestedPoll,
+    NestedPollPlugin,
+)
+
 from ..factories import (
-    get_plugin_position,
-    get_plugin_language,
     PlaceholderFactory,
     PollFactory,
+    get_plugin_language,
+    get_plugin_position,
 )
 
 
@@ -28,3 +34,22 @@ class NestedPollPluginFactory(DjangoModelFactory):
 
     class Meta:
         model = NestedPollPlugin
+
+
+class DeeplyNestedPollFactory(DjangoModelFactory):
+    nested_poll = factory.SubFactory(NestedPollFactory)
+
+    class Meta:
+        model = DeeplyNestedPoll
+
+
+class DeeplyNestedPollPluginFactory(DjangoModelFactory):
+    language = factory.LazyAttribute(get_plugin_language)
+    placeholder = factory.SubFactory(PlaceholderFactory)
+    parent = None
+    position = factory.LazyAttribute(get_plugin_position)
+    plugin_type = "DeeplyNestedPollPlugin"
+    deeply_nested_poll = factory.SubFactory(DeeplyNestedPollFactory)
+
+    class Meta:
+        model = DeeplyNestedPollPlugin

--- a/tests/utils/moderated_polls/factories.py
+++ b/tests/utils/moderated_polls/factories.py
@@ -2,18 +2,17 @@ import factory
 
 from factory.django import DjangoModelFactory
 
-from .models import (
-    DeeplyNestedPoll,
-    DeeplyNestedPollPlugin,
-    NestedPoll,
-    NestedPollPlugin,
-)
-
 from ..factories import (
     PlaceholderFactory,
     PollFactory,
     get_plugin_language,
     get_plugin_position,
+)
+from .models import (
+    DeeplyNestedPoll,
+    DeeplyNestedPollPlugin,
+    NestedPoll,
+    NestedPollPlugin,
 )
 
 

--- a/tests/utils/moderated_polls/factories.py
+++ b/tests/utils/moderated_polls/factories.py
@@ -1,5 +1,4 @@
 import factory
-
 from factory.django import DjangoModelFactory
 
 from ..factories import (

--- a/tests/utils/moderated_polls/factories.py
+++ b/tests/utils/moderated_polls/factories.py
@@ -1,0 +1,30 @@
+import factory
+
+from factory.django import DjangoModelFactory
+
+from .models import NestedPoll, NestedPollPlugin
+from ..factories import (
+    get_plugin_position,
+    get_plugin_language,
+    PlaceholderFactory,
+    PollFactory,
+)
+
+
+class NestedPollFactory(DjangoModelFactory):
+    poll = factory.SubFactory(PollFactory)
+
+    class Meta:
+        model = NestedPoll
+
+
+class NestedPollPluginFactory(DjangoModelFactory):
+    language = factory.LazyAttribute(get_plugin_language)
+    placeholder = factory.SubFactory(PlaceholderFactory)
+    parent = None
+    position = factory.LazyAttribute(get_plugin_position)
+    plugin_type = "NestedPollPlugin"
+    nested_poll = factory.SubFactory(NestedPollFactory)
+
+    class Meta:
+        model = NestedPollPlugin

--- a/tests/utils/moderated_polls/models.py
+++ b/tests/utils/moderated_polls/models.py
@@ -82,3 +82,24 @@ class NestedPollPlugin(CMSPlugin):
 
     def __str__(self):
         return str(self.nested_poll)
+
+
+class DeeplyNestedPoll(models.Model):
+    nested_poll = models.ForeignKey(NestedPoll, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.nested_poll
+
+
+class DeeplyNestedPollPlugin(CMSPlugin):
+    cmsplugin_ptr = models.OneToOneField(
+        CMSPlugin,
+        on_delete=models.CASCADE,
+        related_name="%(app_label)s_%(class)s",
+        parent_link=True,
+    )
+
+    deeply_nested_poll = models.ForeignKey(DeeplyNestedPoll, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return str(self.deeply_nested_poll)

--- a/tests/utils/moderated_polls/models.py
+++ b/tests/utils/moderated_polls/models.py
@@ -61,3 +61,24 @@ class PollPlugin(CMSPlugin):
 
     def __str__(self):
         return str(self.poll)
+
+
+class NestedPoll(models.Model):
+    poll = models.ForeignKey(Poll, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.poll
+
+
+class NestedPollPlugin(CMSPlugin):
+    cmsplugin_ptr = models.OneToOneField(
+        CMSPlugin,
+        on_delete=models.CASCADE,
+        related_name="%(app_label)s_%(class)s",
+        parent_link=True,
+    )
+
+    nested_poll = models.ForeignKey(NestedPoll, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return str(self.nested_poll)

--- a/tests/utils/moderated_polls/templates/polls/deeply_nested_poll.html
+++ b/tests/utils/moderated_polls/templates/polls/deeply_nested_poll.html
@@ -1,0 +1,1 @@
+{% load polls_tags %}{% render_poll instance.deeply_nested_poll.nested_poll.poll %}

--- a/tests/utils/moderated_polls/templates/polls/nested_poll.html
+++ b/tests/utils/moderated_polls/templates/polls/nested_poll.html
@@ -1,0 +1,1 @@
+{% load polls_tags %}{% render_poll instance.nested_poll.poll %}

--- a/tests/utils/moderated_polls/templatetags/polls_tags.py
+++ b/tests/utils/moderated_polls/templatetags/polls_tags.py
@@ -8,9 +8,3 @@ register = template.Library()
 def render_poll(context, instance):
     pollcontent = instance.pollcontent_set.first()
     return {"content": pollcontent}
-
-
-@register.inclusion_tag("polls/poll_tag.html", takes_context=True)
-def render_nested_poll(context, instance):
-    pollcontent = instance.nested_poll.pollcontent_set.first()
-    return {"content": pollcontent}

--- a/tests/utils/moderated_polls/templatetags/polls_tags.py
+++ b/tests/utils/moderated_polls/templatetags/polls_tags.py
@@ -8,3 +8,9 @@ register = template.Library()
 def render_poll(context, instance):
     pollcontent = instance.pollcontent_set.first()
     return {"content": pollcontent}
+
+
+@register.inclusion_tag("polls/poll_tag.html", takes_context=True)
+def render_nested_poll(context, instance):
+    pollcontent = instance.nested_poll.pollcontent_set.first()
+    return {"content": pollcontent}


### PR DESCRIPTION
An issue has been found that placeholder plugin models that attach versionable objects are not automatically added to a collection if the versionable item is deeply nested. 

This fix allows nesting of a versionable item at any level of a placeholders models. 