### PR TITLE
backport: Avoid errors thrown when nested plugins are M2M fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 Unreleased
 ==========
-
+* fix: Avoid errors thrown when nested plugins are M2M fields
 
 1.0.30 (2022-02-03)
 ===================

--- a/djangocms_moderation/helpers.py
+++ b/djangocms_moderation/helpers.py
@@ -163,6 +163,11 @@ def _get_nested_moderated_children_from_placeholder_plugin(instance, placeholder
     Find all nested versionable objects, traverses through all attached models until it finds
     any models that are versioned.
     """
+    # Catch Many to many fields that don't have _meta
+    # FIXME: Handle nested M2M instances
+    if not hasattr(instance, "_meta"):
+        return
+
     for field in instance._meta.get_fields():
         if not field.is_relation or field.auto_created:
             continue

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -35,6 +35,7 @@ from .utils.factories import (
 )
 from .utils.moderated_polls.factories import (
     DeeplyNestedPollPluginFactory,
+    ManytoManyPollPluginFactory,
     NestedPollPluginFactory,
 )
 
@@ -263,6 +264,36 @@ class ModeratedChildrenTestCase(CMSTestCase):
         )
 
         self.assertEqual(moderated_children, [poll_version])
+
+    def test_get_moderated_children_from_placeholder_gets_plugin_with_m2m_fields(self):
+        """
+        FIXME: Currently only checks that a M2M nested poll entry does not cause an error.
+        """
+        pg_version = PageVersionFactory(created_by=self.user)
+        language = pg_version.content.language
+        placeholder = PlaceholderFactory(source=pg_version.content)
+        poll_1_version = PollVersionFactory(
+            created_by=self.user, content__language=language
+        )
+        poll_2_version = PollVersionFactory(
+            created_by=self.user, content__language=language
+        )
+        ManytoManyPollPluginFactory(placeholder=placeholder, polls=[
+            poll_1_version.content.poll,
+            poll_2_version.content.poll,
+        ])
+
+        moderated_children = list(
+            get_moderated_children_from_placeholder(
+                placeholder, {"language": pg_version.content.language}
+            )
+        )
+
+        # FIXME:
+        #       This test is only covering that the M2M field doesn't cause an error.
+        #       It should see that the nested polls are found
+        #       self.assertEqual(moderated_children, [poll_1_version, poll_2_version])
+        self.assertEqual(moderated_children, [])
 
     def test_get_moderated_children_from_placeholder_gets_deeply_nested_models(self):
         """

--- a/tests/utils/moderated_polls/cms_plugins.py
+++ b/tests/utils/moderated_polls/cms_plugins.py
@@ -3,6 +3,7 @@ from cms.plugin_pool import plugin_pool
 
 from .models import (
     DeeplyNestedPollPlugin as DeeplyNestedPoll,
+    ManytoManyPollPlugin as ManytoManyPoll,
     NestedPollPlugin as NestedPoll,
     PollPlugin as Poll,
 )
@@ -30,3 +31,11 @@ class DeeplyNestedPollPlugin(CMSPluginBase):
     name = "DeeplyNestedPoll"
     allow_children = True
     render_template = "polls/deeply_nested_poll.html"
+
+
+@plugin_pool.register_plugin
+class ManytoManyPollPlugin(CMSPluginBase):
+    model = ManytoManyPoll
+    name = "ManytoManyPoll"
+    allow_children = True
+    render_template = "polls/many_polls.html"

--- a/tests/utils/moderated_polls/factories.py
+++ b/tests/utils/moderated_polls/factories.py
@@ -10,6 +10,7 @@ from ..factories import (
 from .models import (
     DeeplyNestedPoll,
     DeeplyNestedPollPlugin,
+    ManytoManyPollPlugin,
     NestedPoll,
     NestedPollPlugin,
 )
@@ -20,6 +21,28 @@ class NestedPollFactory(DjangoModelFactory):
 
     class Meta:
         model = NestedPoll
+
+
+class ManytoManyPollPluginFactory(DjangoModelFactory):
+    language = factory.LazyAttribute(get_plugin_language)
+    placeholder = factory.SubFactory(PlaceholderFactory)
+    parent = None
+    position = factory.LazyAttribute(get_plugin_position)
+    plugin_type = "ManytoManyPollPlugin"
+
+    class Meta:
+        model = ManytoManyPollPlugin
+
+    @factory.post_generation
+    def polls(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of groups were passed in, use them
+            for poll in extracted:
+                self.polls.add(poll)
 
 
 class NestedPollPluginFactory(DjangoModelFactory):

--- a/tests/utils/moderated_polls/models.py
+++ b/tests/utils/moderated_polls/models.py
@@ -103,3 +103,17 @@ class DeeplyNestedPollPlugin(CMSPlugin):
 
     def __str__(self):
         return str(self.deeply_nested_poll)
+
+
+class ManytoManyPollPlugin(CMSPlugin):
+    cmsplugin_ptr = models.OneToOneField(
+        CMSPlugin,
+        on_delete=models.CASCADE,
+        related_name="%(app_label)s_%(class)s",
+        parent_link=True,
+    )
+
+    polls = models.ManyToManyField(Poll)
+
+    def __str__(self):
+        return str(self.polls.first())

--- a/tests/utils/moderated_polls/templates/polls/many_polls.html
+++ b/tests/utils/moderated_polls/templates/polls/many_polls.html
@@ -1,0 +1,1 @@
+{% load polls_tags %}{% render_poll instance.polls.first %}


### PR DESCRIPTION
Changes ported from: https://github.com/django-cms/djangocms-moderation/pull/210