### PR TITLE
fix: Add djangocms-alias to test settings and requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Add djangocms-alias to test settings and requirements
 * fix: Avoid errors thrown when nested plugins are M2M fields
 * fix: Add to collection should automatically add deeply nested draft versioned objects #205
 * fix: Refactor flawed add to collection XSS redirect sanitisation added in 1.0.26

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -18,3 +18,4 @@ https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms
 https://github.com/django-cms/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
 https://github.com/django-cms/djangocms-versioning/tarball/master#egg=djangocms-versioning
 https://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking
+https://github.com/django-cms/djangocms-alias/tarball/master#egg=djangocms-alias

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,6 +5,7 @@ HELPER_SETTINGS = {
         "tests.utils.app_2",
         "djangocms_versioning",
         "djangocms_version_locking",
+        "djangocms_alias",
 
         # the following 4 apps are related
         "aldryn_forms",
@@ -24,6 +25,7 @@ HELPER_SETTINGS = {
         "menus": None,
         "djangocms_versioning": None,
         "djangocms_version_locking": None,
+        "djangocms_alias": None,
         "filer": None,
         "djangocms_moderation": None,
         "aldryn_forms": None,

--- a/tests/test_app_registration.py
+++ b/tests/test_app_registration.py
@@ -87,7 +87,7 @@ class CMSConfigIntegrationTest(CMSTestCase):
         for model in self.moderated_models:
             self.assertIn(model, registered_model)
 
-        self.assertEqual(len(registered_model), 6)
+        self.assertEqual(len(registered_model), 7)
 
 
 class CMSConfigCheck(CMSTestCase):


### PR DESCRIPTION
After pulling the package tests were failing locally due to missing dependency. These changes add the missing dependency and update the test settings so that the test suite runs successfully.
