### PR TITLE
fix: Broken markup and js scripts in the ModerationRequest changelist view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Broken markup and js scripts in the ModerationRequest changelist views
 
 2.1.3 (2022-06-24)
 ==================

--- a/djangocms_moderation/admin.py
+++ b/djangocms_moderation/admin.py
@@ -114,7 +114,11 @@ class ModerationRequestTreeAdmin(TreeAdmin):
     more than once, i.e. they are present in more than one parent.
     """
     class Media:
-        js = ("djangocms_moderation/js/actions.js", "djangocms_moderation/js/burger.js")
+        js = (
+            "admin/js/jquery.init.js",
+            "djangocms_moderation/js/actions.js",
+            "djangocms_moderation/js/burger.js",
+        )
         css = {
             "all": ("djangocms_moderation/css/actions.css", "djangocms_moderation/css/burger.css")
         }
@@ -464,7 +468,7 @@ class ModerationRequestTreeAdmin(TreeAdmin):
 
 class ModerationRequestAdmin(admin.ModelAdmin):
     class Media:
-        js = ('djangocms_moderation/js/actions.js',)
+        js = ('admin/js/jquery.init.js', 'djangocms_moderation/js/actions.js',)
 
     inlines = [ModerationRequestActionInline]
 
@@ -1000,7 +1004,7 @@ class WorkflowAdmin(admin.ModelAdmin):
 
 class ModerationCollectionAdmin(admin.ModelAdmin):
     class Media:
-        js = ("djangocms_moderation/js/actions.js",)
+        js = ("admin/js/jquery.init.js", "djangocms_moderation/js/actions.js",)
         css = {"all": ("djangocms_moderation/css/actions.css",)}
 
     actions = None  # remove `delete_selected` for now, it will be handled later

--- a/djangocms_moderation/templates/djangocms_moderation/moderation_request_change_list.html
+++ b/djangocms_moderation/templates/djangocms_moderation/moderation_request_change_list.html
@@ -4,14 +4,14 @@
 {% block extrahead %}
     {# INFO: moderation_static_url_prefix variable is used to inject static_url into actions.js #}
     <script>
-        let moderation_static_url_prefix = "{% static "djangocms_moderation/" %}";
+        let moderation_static_url_prefix = "{% static 'djangocms_moderation/' %}";
     </script>
     {{ block.super }}
-    {#
-        INFO: we need to add styles here instead of "extrastyle" to avoid
+    {% comment "INFO" %}
+        We need to add styles here instead of "extrastyle" to avoid
         conflicts with adminstyle. We are adding cms.base.css to gain the
         icon support, e.g. `<span class="cms-icon cms-icon-eye"></span>`
-    #}
+    {% endcomment %}
     <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}">
 {% endblock extrahead %}
 


### PR DESCRIPTION
The cms styles and mark up were injected into the body tag, this had a knock on effect with loaded js too where the globals from django were not added from the i18n.js file among other things.

![Screenshot 2022-07-08 at 11 42 44](https://user-images.githubusercontent.com/12543977/177978085-4b1aab6a-ad21-4e73-a8d2-9689e62d1d72.png)


