### PR TITLE
Fix: Problems from alias failing tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ INSTALL_REQUIREMENTS = [
     "django-sekizai>=0.7",
     "django-admin-sortable2>=0.6.4",
 ]
+DEPENDENCY_LINKS = [
+    "https://github.com/django-cms/django-cms/tarball/release/4.0.1.x#egg=django-cms",
+    "https://github.com/django-cms/djangocms-versioning/tarball/1.2.2#egg=djangocms-versioning",
+]
 
 setup(
     name="djangocms-moderation",
@@ -25,6 +29,7 @@ setup(
         "Topic :: Software Development",
     ],
     install_requires=INSTALL_REQUIREMENTS,
+    dependency_links=DEPENDENCY_LINKS,
     author="Divio AG",
     author_email="info@divio.ch",
     maintainer='Django CMS Association and contributors',

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -18,4 +18,4 @@ https://github.com/django-cms/django-cms/tarball/release/4.0.1.x#egg=django-cms
 https://github.com/django-cms/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor
 https://github.com/django-cms/djangocms-versioning/tarball/1.2.2#egg=djangocms-versioning
 https://github.com/FidelityInternational/djangocms-version-locking/tarball/1.2.0#egg=djangocms-version-locking
-https://github.com/django-cms/djangocms-alias/tarball/master#egg=djangocms-alias
+https://github.com/django-cms/djangocms-alias/tarball/support/django-cms-4.0.x#egg=djangocms-alias

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,20 @@
 [tox]
 envlist =
-    dj32-flake8
-    dj32-isort
-    py{37,38,39}-dj{22,32}-sqlite-cms4
+    flake8
+    isort
+    py{38,39}-dj{22,32}-sqlite-cms4
 
 skip_missing_interpreters=True
 
 [testenv]
 deps =
-    dj22: -r{toxinidir}/tests/requirements/django_22.txt
+    dj22: -r{toxinidir}/tests/requirements/dj22_cms40.txt
     dj22: Django>=2.2,<2.3
 
-    dj32: -r{toxinidir}/tests/requirements/django_32.txt
+    dj32: -r{toxinidir}/tests/requirements/dj32_cms40.txt
     dj32: Django>=3.2,<3.3
 
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
 
@@ -26,9 +25,11 @@ commands =
     {env:COMMAND:coverage} report
 
 [testenv:flake8]
-commands = flake8
 basepython = python3.9
+commands = flake8
+deps = flake8
 
 [testenv:isort]
-commands = isort --recursive --check-only --diff {toxinidir}
 basepython = python3.9
+commands = isort --check-only --diff {toxinidir}
+deps = isort


### PR DESCRIPTION
This fixes parts of the setup that were causing test failures.

**Test failures still exist**.

Checks on `ModerationRequest` and related things that try to count the moderation queue are still broken.