### PR TITLE
fix: Replace `SortableAdminMixin` by `SortableAdminBase` for `WorkflowAdmin`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         python setup.py install
 
     - name: Run coverage
-      run: coverage run setup.py test
+      run: coverage run ./tests/settings.py
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
             dj50_cms41.txt,
             dj42_cms41.txt,
             dj42_cms40.txt,
-            dj32_cms40.txt,
         ]
         os: [
             ubuntu-20.04,

--- a/djangocms_moderation/admin.py
+++ b/djangocms_moderation/admin.py
@@ -16,7 +16,7 @@ from cms.admin.placeholderadmin import PlaceholderAdminMixin
 from cms.toolbar.utils import get_object_preview_url
 from cms.utils.helpers import is_editable_model
 
-from adminsortable2.admin import SortableAdminMixin, SortableInlineAdminMixin
+from adminsortable2.admin import SortableAdminBase, SortableInlineAdminMixin
 from treebeard.admin import TreeAdmin
 
 from . import constants, signals
@@ -1011,7 +1011,7 @@ class WorkflowStepInline(SortableInlineAdminMixin, admin.TabularInline):
 
 
 @admin.register(Workflow)
-class WorkflowAdmin(SortableAdminMixin, admin.ModelAdmin):
+class WorkflowAdmin(SortableAdminBase, admin.ModelAdmin):
     inlines = [WorkflowStepInline]
     list_display = ["name", "is_default"]
     fields = [

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -18,7 +18,6 @@ from djangocms_moderation.constants import ACTION_REJECTED
 from djangocms_moderation.models import (
     ModerationCollection,
     ModerationRequest,
-    WorkflowStep,
 )
 
 from .utils.base import BaseTestCase, MockRequest
@@ -433,16 +432,6 @@ class ModerationAdminChangelistConfigurationTestCase(BaseTestCase):
         self.assertContains(response, '/static/djangocms_moderation/js/burger.js')
 
     def test_workflow_admin_renders_correctly(self):
-        WorkflowStep.objects.create(
-            workflow=self.wf,
-            role=self.role1,
-            order=0,
-        )
-        WorkflowStep.objects.create(
-            workflow=self.wf,
-            role=self.role3,
-            order=1,
-        )
         url = admin_reverse("djangocms_moderation_workflow_change", args=(self.wf.pk,))
 
         with self.login_user_context(self.get_superuser()):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,9 +1,10 @@
-from cms.utils.urlutils import admin_reverse
 from django.contrib import admin
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.test.client import RequestFactory
 from django.urls import reverse
+
+from cms.utils.urlutils import admin_reverse
 
 from djangocms_versioning.test_utils import factories
 
@@ -14,7 +15,11 @@ from djangocms_moderation.admin import (
     ModerationRequestTreeAdmin,
 )
 from djangocms_moderation.constants import ACTION_REJECTED
-from djangocms_moderation.models import ModerationCollection, ModerationRequest, WorkflowStep
+from djangocms_moderation.models import (
+    ModerationCollection,
+    ModerationRequest,
+    WorkflowStep,
+)
 
 from .utils.base import BaseTestCase, MockRequest
 from .utils.factories import (

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -15,10 +15,7 @@ from djangocms_moderation.admin import (
     ModerationRequestTreeAdmin,
 )
 from djangocms_moderation.constants import ACTION_REJECTED
-from djangocms_moderation.models import (
-    ModerationCollection,
-    ModerationRequest,
-)
+from djangocms_moderation.models import ModerationCollection, ModerationRequest
 
 from .utils.base import BaseTestCase, MockRequest
 from .utils.factories import (


### PR DESCRIPTION
## Description

When updating to django-sortable-admin2 two mixin classes were accidentially exchanged... This PR fixes it.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #277 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)
