### PR TITLE
fix: Update check framework to not allow publishing for moderated models

### DIFF
--- a/djangocms_moderation/monkeypatch.py
+++ b/djangocms_moderation/monkeypatch.py
@@ -5,6 +5,7 @@ from cms.models import fields
 from cms.utils.urlutils import add_url_parameters
 
 from djangocms_versioning import admin, models
+from djangocms_versioning.conditions import Conditions
 from djangocms_versioning.constants import DRAFT
 from djangocms_versioning.exceptions import ConditionFailed
 from djangocms_versioning.helpers import version_list_url
@@ -120,6 +121,16 @@ def _get_publish_link(func):
     return inner
 
 
+def _fail(message):
+    """
+    Make a check condition fail always
+    """
+    def inner(version, user):
+        raise ConditionFailed(message)
+
+    return inner
+
+
 admin.VersionAdmin._get_publish_link = _get_publish_link(
     admin.VersionAdmin._get_publish_link
 )
@@ -152,5 +163,8 @@ models.Version.check_edit_redirect += [
         _("Cannot edit a version in an active moderation collection")
     )
 ]
+models.Version.check_publish = Conditions([
+    _fail(_("Content cannot be published directly. Use the moderation process."))
+])
 
 fields.PlaceholderRelationField.default_checks += [_is_placeholder_review_unlocked]

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -440,3 +440,11 @@ class ModerationAdminChangelistConfigurationTestCase(BaseTestCase):
         # django-admin-sortable2 injected its inputs
         self.assertContains(result, '<script src="/static/adminsortable2/js/adminsortable2.min.js"></script>')
         self.assertContains(result, '<input type="hidden" name="steps-0-id"')
+
+    def test_moderated_models_cannot_be_published(self):
+        from djangocms_versioning.exceptions import ConditionFailed
+
+        version = self.mr1.version
+
+        with self.assertRaises(ConditionFailed):
+            version.check_publish(self.get_superuser())


### PR DESCRIPTION
## Description

This PR avoids publishing moderated content by directly posting to versioning endpoints.

It updates versioning's check framework to prohibit this.

Tests are coming up.
## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)
