### PR TITLE
Added data-popup attr to a tag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+fix: Add data-popup attr to a tag in burger menu item
 fix: Replace SortableAdminMixin by SortableAdminBase for WorkflowAdmin
 fix: Restore "In Collection" button in the toolbar
 

--- a/djangocms_moderation/static/djangocms_moderation/js/burger.js
+++ b/djangocms_moderation/static/djangocms_moderation/js/burger.js
@@ -147,6 +147,7 @@
                 let li_anchor = document.createElement('a');
                 const itemId = $(item).attr('id');
                 const itemTarget = $(item).attr('target');
+                const itemDataPopup = $(item).attr('data-popup');
 
                 li_anchor.setAttribute('class', 'cms-actions-dropdown-menu-item-anchor');
                 li_anchor.setAttribute('href', $(item).attr('href'));
@@ -157,6 +158,10 @@
                 // Copy the target attribute if it is set
                 if (itemTarget !== undefined) {
                     li_anchor.setAttribute('target', itemTarget);
+                }
+                // Copy the data-popup attribute if it is set
+                if (itemDataPopup !== undefined) {
+                    li_anchor.setAttribute('data-popup', itemDataPopup);
                 }
 
                 if ($(item).hasClass('cms-form-get-method')) {


### PR DESCRIPTION
## Description
Added an attribute from parent a tag to be included in burger menu item.

Attribute name: data-popup

Data popup is needed to open a link in burger menu in another window. this value is present in the original html of the link but not included while creating the burger menu.
for your reference: https://github.com/FidelityInternational/djangocms-content-expiry/blob/main/djangocms_content_expiry/templates/djangocms_content_expiry/calendar_icon.html
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)

## Summary by Sourcery

New Features:
- Add support for 'data-popup' attribute in burger menu items.