### PR TITLE
chore: upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,4 @@ jobs:
       run: coverage run ./tests/settings.py
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6


### PR DESCRIPTION
## Summary
- upgrade outdated GitHub Actions versions listed in the repository audit
- align workflow action references with their current supported versions

## Testing
- not run (workflow-only change)

## Summary by Sourcery

CI:
- Bump Codecov upload step in the test workflow from v5 to v6.