### PR TITLE
tests: Failed due to stale cache

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,12 +22,15 @@ class VersionLockingTestCase(BaseTestCase):
         version.publish(self.user)
         # reload version to update cache
         version = Version.objects.get_for_content(version.content)
-        self.assertTrue(is_obj_version_unlocked(version.content, self.user2))
+        content = version.content
+        if hasattr(content, "prefetched_versions"):
+            del content.prefetched_versions
+        self.assertTrue(is_obj_version_unlocked(content, self.user2))
 
         # Make sure that we are actually calling the version-lock method and it
         # still exists
         with mock.patch(
             "djangocms_moderation.helpers.content_is_unlocked_for_user"
         ) as _mock:
-            is_obj_version_unlocked(version.content, self.user2)
-            _mock.assert_called_once_with(version.content, self.user2)
+            is_obj_version_unlocked(content, self.user2)
+            _mock.assert_called_once_with(content, self.user2)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,11 +20,7 @@ class VersionLockingTestCase(BaseTestCase):
         self.assertTrue(is_obj_version_unlocked(version.content, self.user))
         self.assertFalse(is_obj_version_unlocked(version.content, self.user2))
         version.publish(self.user)
-        # reload version to update cache
-        version = Version.objects.get_for_content(version.content)
-        content = version.content
-        if hasattr(content, "prefetched_versions"):
-            del content.prefetched_versions
+        content = type(version.content)._base_manager.get(pk=version.content.pk)
         self.assertTrue(is_obj_version_unlocked(content, self.user2))
 
         # Make sure that we are actually calling the version-lock method and it


### PR DESCRIPTION
## Summary by Sourcery

Ensure integration test for version unlock uses a fresh content instance without stale prefetch cache before asserting unlock behavior.

Bug Fixes:
- Clear prefetched version cache in the integration test to avoid false results caused by stale content prefetching.

Tests:
- Update integration test to operate on a cleaned content object and adjust assertions to use the same instance consistently.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/main/CONTRIBUTING.rst)