### PR TITLE
fix: pass content language to create moderation link (#392)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Unreleased
+==========
+
+* fix: removed the hardcoded "en" language when generating the moderation link
+  and pass the admins language
+
 2.4.0 (2026-07-06)
 ==================
 * feat: When approving moderation requests in bulk, the user now gets clear

--- a/djangocms_moderation/admin_actions.py
+++ b/djangocms_moderation/admin_actions.py
@@ -142,11 +142,7 @@ def add_items_to_collection(modeladmin, request, queryset):
     version_ids = [str(x) for x in version_ids]
     if version_ids:
         admin_url = add_url_parameters(
-            get_admin_url(
-                name="cms_moderation_items_to_collection",
-                language=request.GET.get("language"),
-                args=(),
-            ),
+            get_admin_url(name="cms_moderation_items_to_collection"),
             version_ids=",".join(version_ids),
             return_to_url=request.headers.get("referer", ""),
         )

--- a/djangocms_moderation/monkeypatch.py
+++ b/djangocms_moderation/monkeypatch.py
@@ -46,9 +46,7 @@ def _get_moderation_link(self, version, request):
         return format_html('<a href="{}">{}</a>', url, title)
     elif is_obj_version_unlocked(content_object, request.user):
         url = add_url_parameters(
-            get_admin_url(
-                name="cms_moderation_items_to_collection", language="en", args=()
-            ),
+            get_admin_url(name="cms_moderation_items_to_collection"),
             version_ids=version.pk,
             return_to_url=version_list_url(version.content),
         )

--- a/djangocms_moderation/utils.py
+++ b/djangocms_moderation/utils.py
@@ -21,7 +21,9 @@ def get_absolute_url(location, site=None):
     return urljoin(domain, location)
 
 
-def get_admin_url(name, language, args):
+def get_admin_url(name, language=None, args=()):
+    if not language:
+        return admin_reverse(name, args=args)
     with force_language(language):
         return admin_reverse(name, args=args)
 

--- a/tests/test_monkeypatch.py
+++ b/tests/test_monkeypatch.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from django.contrib import admin
 from django.urls import reverse
+from django.utils import translation
 
 from cms.models import PageContent
 from cms.models.fields import PlaceholderRelationField
@@ -131,6 +132,17 @@ class VersionAdminMonkeypatchTestCase(BaseTestCase):
         # Now the version lock is lifted, so we should be able to add to moderation
         link = self.version_admin._get_moderation_link(draft_version, self.mock_request)
         self.assertIn("Submit for moderation", link)
+
+    def test_get_moderation_link_with_correct_language(self):
+        draft_version = PageVersionFactory(created_by=self.mock_request.user)
+
+        def _test_for_language(language):
+            with self.subTest(f"with language '{language}'"), translation.override(language):
+                link = self.version_admin._get_moderation_link(draft_version, self.mock_request)
+                self.assertIn(f'href="/{language}/admin/djangocms_moderation/', link)
+
+        _test_for_language("de-de")
+        _test_for_language("de")
 
     @mock.patch("djangocms_moderation.monkeypatch.is_registered_for_moderation")
     def test_get_moderation_link_when_not_registered(


### PR DESCRIPTION
## Description

* Removed the hardcoded "en" language and pass the requests language to generate the moderation link. In terms of consistency I chose this way as three or four other parts in this project use the requests language to retrieve the admin url (`def get_admin_url`).

* Added a test case in `test_monkeypatch.py` for this behavior.

## Related resources

* fixes #392 

## Checklist

* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/main/CONTRIBUTING.rst)

## Summary by Sourcery

Use the active request language when generating moderation links and verify localized URLs.

Bug Fixes:
- Ensure moderation links use the active request language instead of a hardcoded English locale.

Enhancements:
- Make admin URL generation preserve the current language by default while retaining support for explicit language overrides.

Tests:
- Add coverage confirming moderation links resolve correctly for German language variants.