### PR TITLE
fix: Apply security hardening fixes

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+name: "djangocms-moderation CodeQL config"
+
+# Vendored, unmodified third-party libraries. They generate hundreds of
+# "quality" findings that we cannot act on without diverging from upstream,
+# which drowns out the real security alerts.
+# htmldiff.js is deliberately NOT excluded: it is a django-cms fork that we
+# maintain ourselves.
+paths-ignore:
+  - djangocms_moderation/static/djangocms_moderation/js/libs/tidy.js
+  - djangocms_moderation/static/djangocms_moderation/js/libs/difflib.js
+  - djangocms_moderation/static/djangocms_moderation/js/libs/diffview.js
+  - djangocms_moderation/static/**/*.min.js

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/djangocms_moderation/static/djangocms_moderation/js/libs/htmldiff.js
+++ b/djangocms_moderation/static/djangocms_moderation/js/libs/htmldiff.js
@@ -78,8 +78,8 @@
      *    null otherwise
      */
     function isStartOfAtomicTag(word) {
-        var result = /^(<(iframe|object|math|svg|script|video)|^<[\s\S]*?data-cms-diff-ignore[\s\S]*>$)/.exec(word);
-        return result && result[1];
+        var result = /^<(iframe|object|math|svg|script|video)|^<([^\s/>]+)[\s\S]*?data-cms-diff-ignore[\s\S]*>$/i.exec(word);
+        return result && (result[1] || result[2]).toLowerCase();
     }
 
     /**
@@ -93,7 +93,7 @@
      *    false otherwise.
      */
     function isEndOfAtomicTag(word, tag) {
-        return word.substring(word.length - tag.length - 2) === '</' + tag;
+        return word.substring(word.length - tag.length - 2).toLowerCase() === '</' + tag;
     }
 
     /**

--- a/djangocms_moderation/views.py
+++ b/djangocms_moderation/views.py
@@ -95,17 +95,15 @@ class CollectionItemsView(FormView):
         """
         return_to_url = self.request.GET.get("return_to_url")
         if return_to_url:
-            url_is_safe = url_has_allowed_host_and_scheme(
+            if not url_has_allowed_host_and_scheme(
                 url=return_to_url,
                 allowed_hosts=self.request.get_host(),
                 require_https=self.request.is_secure(),
-            )
-            # Protect against refracted XSS attacks
+            ):
+                return HttpResponseRedirect(self.request.path)
+            # Protect against reflected XSS attacks
             # Allow : in http://, ?=& for GET parameters
-            return_to_url = quote(return_to_url, safe='/:?=&')
-            if not url_is_safe:
-                return_to_url = self.request.path
-            return HttpResponseRedirect(return_to_url)
+            return HttpResponseRedirect(quote(return_to_url, safe="/:?=&"))
 
         success_template = "djangocms_moderation/request_finalized.html"
         return render(self.request, success_template, {})

--- a/djangocms_moderation/views.py
+++ b/djangocms_moderation/views.py
@@ -1,4 +1,4 @@
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 from django.contrib import admin, messages
 from django.db import transaction
@@ -25,6 +25,23 @@ from .utils import get_admin_url
 
 
 from . import conf, constants  # isort:skip
+
+
+def _as_site_relative_url(url):
+    """
+    Reduce ``url`` to a site-relative path, dropping any scheme and host.
+
+    Stripping the leading slashes before prepending a single literal "/" means
+    the result can never be an absolute or a protocol-relative
+    ("//evil.example.com") URL, whatever was passed in. Quoting the remainder
+    protects against reflected XSS in the redirect target, while keeping the
+    characters that legitimately separate a path and its query string.
+    """
+    parts = urlsplit(url)
+    relative_url = "/" + quote(parts.path.lstrip("/"), safe="/")
+    if parts.query:
+        relative_url += "?" + quote(parts.query, safe="/=&")
+    return relative_url
 
 
 @method_decorator(transaction.atomic, name="post")
@@ -100,10 +117,8 @@ class CollectionItemsView(FormView):
                 allowed_hosts=self.request.get_host(),
                 require_https=self.request.is_secure(),
             ):
-                return HttpResponseRedirect(self.request.path)
-            # Protect against reflected XSS attacks
-            # Allow : in http://, ?=& for GET parameters
-            return HttpResponseRedirect(quote(return_to_url, safe="/:?=&"))
+                return_to_url = self.request.path
+            return HttpResponseRedirect(_as_site_relative_url(return_to_url))
 
         success_template = "djangocms_moderation/request_finalized.html"
         return render(self.request, success_template, {})

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -622,6 +622,49 @@ class CollectionItemsViewAddingRequestsTestCase(CMSTestCase):
             messages,
         )
 
+    def test_collection_redirect_url_cannot_leave_the_site(self):
+        """
+        Open redirect protection: whatever ``return_to_url`` contains, the
+        Location header must stay a site-relative path. In particular a
+        protocol-relative URL ("//evil.example.com") must not survive.
+        """
+        user = self.get_superuser()
+
+        for return_to_url in (
+            "//evil.example.com/pwn",
+            "///evil.example.com/pwn",
+            "https://evil.example.com/pwn",
+            "http://evil.example.com/pwn?next=1",
+            "/\\evil.example.com",
+        ):
+            with self.subTest(return_to_url=return_to_url):
+                collection = ModerationCollectionFactory(author=user)
+                page_version = PageVersionFactory(created_by=user)
+                url = add_url_parameters(
+                    get_admin_url(
+                        name="cms_moderation_items_to_collection",
+                        language="en",
+                        args=(),
+                    ),
+                    return_to_url=return_to_url,
+                    version_ids=page_version.pk,
+                    collection_id=collection.pk,
+                )
+                with self.login_user_context(user):
+                    response = self.client.post(
+                        path=url,
+                        data={
+                            "collection": collection.pk,
+                            "versions": page_version.pk,
+                        },
+                        follow=False,
+                    )
+
+                self.assertEqual(response.status_code, 302)
+                self.assertTrue(response.url.startswith("/"))
+                self.assertFalse(response.url.startswith("//"))
+                self.assertNotIn("evil.example.com", response.url)
+
 
 class ModerationCollectionTestCase(CMSTestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary by Sourcery

Apply security hardening to redirect sanitization, HTML diff processing, and CodeQL analysis.

Bug Fixes:
- Harden redirect handling to prevent external and protocol-relative return URLs from escaping the site or enabling reflected XSS.
- Improve HTML diff tag handling for case-insensitive custom atomic tags and closing tags.

Enhancements:
- Configure CodeQL to ignore findings from vendored and minified third-party JavaScript while continuing to scan maintained code.

CI:
- Apply the repository-specific CodeQL configuration to security and quality analysis.

Tests:
- Add coverage confirming malicious return URLs always produce site-relative redirects.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes https://github.com/django-cms/djangocms-moderation/security/code-scanning/2
* fixes https://github.com/django-cms/djangocms-moderation/security/code-scanning/396

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/main/CONTRIBUTING.rst)